### PR TITLE
Nginx third party

### DIFF
--- a/Ingress/controllers/nginx-alpha/controller.go
+++ b/Ingress/controllers/nginx-alpha/controller.go
@@ -60,6 +60,7 @@ http {
 {{range $rule := $ing.Spec.Rules}}
   server {
     listen 80;
+    listen 443;
     server_name {{$rule.Host}};
 {{ range $path := $rule.HTTP.Paths }}
     location {{$path.Path}} {
@@ -94,7 +95,7 @@ func main() {
 	if kubeClient, err := client.NewInCluster(); err != nil {
 		log.Fatalf("Failed to create client: %v.", err)
 	} else {
-		ingClient = kubeClient.Extensions().Ingress("default")
+		ingClient = kubeClient.Extensions().Ingress("devops-test")
 	}
 	tmpl, _ := template.New("nginx").Parse(nginxConf)
 	rateLimiter := util.NewTokenBucketRateLimiter(0.1, 1)

--- a/Ingress/controllers/nginx-third-party/Dockerfile
+++ b/Ingress/controllers/nginx-third-party/Dockerfile
@@ -12,7 +12,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-FROM gcr.io/google_containers/nginx-slim:0.2
+#FROM gcr.io/google_containers/nginx-slim:0.2
+FROM vungle/nginx-slim:edge
 
 COPY nginx-third-party-lb /
 COPY nginx.tmpl /

--- a/Ingress/controllers/nginx-third-party/Dockerfile
+++ b/Ingress/controllers/nginx-third-party/Dockerfile
@@ -13,7 +13,9 @@
 # limitations under the License.
 
 #FROM gcr.io/google_containers/nginx-slim:0.2
-FROM vungle/nginx-slim:edge
+#FROM vungle/nginx-slim:edge
+#FROM gcr.io/google_containers/nginx
+FROM vungle/nginx-slim:3.3
 
 COPY nginx-third-party-lb /
 COPY nginx.tmpl /

--- a/Ingress/controllers/nginx-third-party/nginx.tmpl
+++ b/Ingress/controllers/nginx-third-party/nginx.tmpl
@@ -88,9 +88,10 @@ http {
     access_log /var/log/nginx/access.log upstreaminfo;
     error_log  /var/log/nginx/error.log {{ $cfg.ErrorLogLevel }};
 
-    {{ if not (empty .defResolver) }}# Custom dns resolver.
-    resolver {{ .defResolver }} valid=30s;
-    {{ end }}
+    #{{ if not (empty .defResolver) }}# Custom dns resolver.
+    #resolver {{ .defResolver }} valid=30s;
+    #{{ end }}
+    resolver 10.100.0.10 valid=30s;
 
     map $http_upgrade $connection_upgrade {
         default upgrade;

--- a/Ingress/controllers/nginx-third-party/nginx.tmpl
+++ b/Ingress/controllers/nginx-third-party/nginx.tmpl
@@ -73,7 +73,8 @@ http {
     gzip_vary on;
     {{ end }}
 
-    client_max_body_size "{{ $cfg.BodySize }}";
+    #client_max_body_size "{{ $cfg.BodySize }}";
+    client_max_body_size "2000m";
 
     {{ if $cfg.UseProxyProtocol }}
     set_real_ip_from {{ $cfg.ProxyRealIpCidr }};

--- a/Ingress/controllers/nginx-third-party/nginx/main.go
+++ b/Ingress/controllers/nginx-third-party/nginx/main.go
@@ -33,7 +33,7 @@ import (
 const (
 	// http://nginx.org/en/docs/http/ngx_http_core_module.html#client_max_body_size
 	// Sets the maximum allowed size of the client request body
-	bodySize = "1m"
+	bodySize = "2000m"
 
 	// http://nginx.org/en/docs/ngx_core_module.html#error_log
 	// Configures logging level [debug | info | notice | warn | error | crit | alert | emerg]

--- a/Ingress/images/nginx-slim/Dockerfile
+++ b/Ingress/images/nginx-slim/Dockerfile
@@ -13,7 +13,12 @@
 # limitations under the License.
 
 
-FROM alpine:edge
+#FROM alpine:edge
+FROM sillelien/base-alpine:0.10
+	# https://github.com/sillelien/base-alpine#dns-and-the-alpine-resolvconf-problem
+
+FROM janeczku/alpine-kubernetes:3.3
+	# https://github.com/janeczku/docker-alpine-kubernetes
 
 RUN apk add --update-cache bash && \
   rm -rf /var/cache/apk/*

--- a/Ingress/images/nginx-slim/Dockerfile
+++ b/Ingress/images/nginx-slim/Dockerfile
@@ -13,12 +13,12 @@
 # limitations under the License.
 
 
-FROM alpine:3.2
+FROM alpine:edge
 
 RUN apk add --update-cache bash && \
   rm -rf /var/cache/apk/*
 
-COPY build.sh /tmp
+COPY build.sh /tmp/
 
 RUN /tmp/build.sh
 

--- a/Ingress/images/nginx-slim/Dockerfile
+++ b/Ingress/images/nginx-slim/Dockerfile
@@ -14,7 +14,7 @@
 
 
 #FROM alpine:edge
-FROM sillelien/base-alpine:0.10
+#FROM sillelien/base-alpine:0.10
 	# https://github.com/sillelien/base-alpine#dns-and-the-alpine-resolvconf-problem
 
 FROM janeczku/alpine-kubernetes:3.3


### PR DESCRIPTION
- docker base image alpine 3.x has the non complete DNS implementation.  It would not resolve any of the nginx proxy urls.  These guys were having the same problem:  https://groups.google.com/forum/#!topic/google-containers/oxRNHFr7jm0  I moved it to the alpine edge release.  Seems to work a lot better
- Changed client body size to 2GB.  Hard coded it for now.  Need to come back and set it in the config it sources.
